### PR TITLE
Reject on error instead of Resolve.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 var http = require("http");
 var Promise = require("bluebird");
 function ping(url, port) {
-    var promise = new Promise(function (resolve) {
+    var promise = new Promise(function (resolve, reject) {
         var result;
         var options = { host: url, port: port || 80, path: '/' };
         var start = Date.now();
@@ -12,7 +12,7 @@ function ping(url, port) {
         });
         pingRequest.on("error", function () {
             result = -1;
-            resolve(result);
+            reject(result);
             pingRequest.abort();
         });
         pingRequest.write("");


### PR DESCRIPTION
Instead of using resolve in the pingRequest.on("error") handler use reject so that a consumer can write their ping code like

``` javascript
ping('http://localhost', 1234)
    .then(successCallback)
    .catch(failureCallback);
```
